### PR TITLE
[ASSIGNMENT] 3차 과제 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -22,4 +22,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // mysql
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }

--- a/src/main/java/org/sopt/Main.java
+++ b/src/main/java/org/sopt/Main.java
@@ -2,7 +2,9 @@ package org.sopt;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Main {
     public static void main(String[] args) {

--- a/src/main/java/org/sopt/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package org.sopt.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI assignmentOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Post API")
+                        .description("게시글 API 명세서")
+                        .version("v1.0.0"));
+    }
+}

--- a/src/main/java/org/sopt/controller/LikeController.java
+++ b/src/main/java/org/sopt/controller/LikeController.java
@@ -1,0 +1,46 @@
+package org.sopt.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.dto.request.LikeRequest;
+import org.sopt.dto.response.ApiResponse;
+import org.sopt.service.LikeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Like", description = "좋아요 관련 API")
+@RestController
+@RequestMapping("/posts")
+public class LikeController {
+    private final LikeService likeService;
+
+    public LikeController(LikeService likeService) {
+        this.likeService = likeService;
+    }
+
+    @Operation(summary = "좋아요 추가", description = "사용자가 특정 게시글에 좋아요를 추가합니다.")
+    @PostMapping("/{postId}/likes")
+    public ResponseEntity<ApiResponse<Void>> addLike(
+            @PathVariable Long postId,
+            @RequestBody LikeRequest request
+    ) {
+        likeService.addLike(postId, request);
+
+        return ResponseEntity.ok(
+                ApiResponse.success("좋아요 추가 완료!", null)
+        );
+    }
+
+    @Operation(summary = "좋아요 취소", description = "사용자가 특정 게시글에 누른 좋아요를 취소합니다.")
+    @DeleteMapping("/{postId}/likes")
+    public ResponseEntity<ApiResponse<Void>> cancelLike(
+            @PathVariable Long postId,
+            @RequestBody LikeRequest request
+    ) {
+        likeService.cancelLike(postId, request);
+
+        return ResponseEntity.ok(
+                ApiResponse.success("좋아요 취소 완료!", null)
+        );
+    }
+}

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -1,5 +1,6 @@
 package org.sopt.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.ApiResponse;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Post", description = "게시글 관련 API")
 @RestController
 @RequestMapping("/posts")
 public class PostController {

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -1,5 +1,11 @@
 package org.sopt.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
@@ -25,8 +31,64 @@ public class PostController {
     }
 
     // POST /posts
+    @Operation(
+            summary = "게시글 작성",
+            description = "작성자 userId, 제목, 내용을 받아 게시글을 작성합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "게시글 작성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "message": "게시글 등록 완료!",
+                                              "data": {
+                                                "id": 1
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 사용자",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "message": "존재하지 않는 사용자입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @PostMapping
     public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "게시글 작성 요청 body",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = CreatePostRequest.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "userId": 1,
+                                              "title": "첫 번째 게시글",
+                                              "content": "게시글 내용입니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
             @RequestBody CreatePostRequest request
     ) {
         CreatePostResponse response = postService.createPost(request);
@@ -37,9 +99,42 @@ public class PostController {
     }
 
     // GET /posts?page=0&size=10
+    @Operation(
+            summary = "게시글 목록 조회",
+            description = "게시글 목록을 페이지네이션으로 조회합니다. page는 0부터 시작합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "message": "게시글 목록 조회 성공!",
+                                              "data": [
+                                                {
+                                                  "id": 1,
+                                                  "title": "첫 번째 게시글",
+                                                  "content": "게시글 내용입니다.",
+                                                  "author": "가윤",
+                                                  "createdAt": "2026-05-01T16:57:20.105"
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping
     public ResponseEntity<ApiResponse<List<PostResponse>>> getAllPosts(
+            @Parameter(description = "페이지 번호, 0부터 시작", example = "0")
             @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "한 페이지에 조회할 게시글 개수", example = "10")
             @RequestParam(defaultValue = "10") int size
     ) {
         List<PostResponse> responses = postService.getAllPosts(page, size);
@@ -50,8 +145,53 @@ public class PostController {
     }
 
     // GET /posts/{id}
+    @Operation(
+            summary = "게시글 단건 조회",
+            description = "게시글 id를 이용해 특정 게시글을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 단건 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "message": "게시글 단건 조회 성공!",
+                                              "data": {
+                                                "id": 1,
+                                                "title": "첫 번째 게시글",
+                                                "content": "게시글 내용입니다.",
+                                                "author": "가윤",
+                                                "createdAt": "2026-05-01T16:57:20.105"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 게시글",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "message": "게시글을 찾을 수 없습니다. id: 1",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<PostResponse>> getPost(
+            @Parameter(description = "조회할 게시글 id", example = "1", required = true)
             @PathVariable Long id
     ) {
         PostResponse response = postService.getPost(id);
@@ -62,9 +202,64 @@ public class PostController {
     }
 
     // PUT /posts/{id}
+    @Operation(
+            summary = "게시글 수정",
+            description = "게시글 id를 이용해 특정 게시글의 제목과 내용을 수정합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 수정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "message": "게시글 수정 완료!",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 게시글",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "message": "존재하지 않는 게시글입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> updatePost(
+            @Parameter(description = "수정할 게시글 id", example = "1", required = true)
             @PathVariable Long id,
+
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "게시글 수정 요청 body",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = UpdatePostRequest.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "title": "수정된 제목",
+                                              "content": "수정된 게시글 내용입니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
             @RequestBody UpdatePostRequest request
     ) {
         postService.updatePost(id, request);
@@ -75,8 +270,47 @@ public class PostController {
     }
 
     // DELETE /posts/{id}
+    @Operation(
+            summary = "게시글 삭제",
+            description = "게시글 id를 이용해 특정 게시글을 삭제합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "message": "게시글 삭제 완료!",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 게시글",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "message": "게시글을 찾을 수 없습니다. id: 1",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deletePost(
+            @Parameter(description = "삭제할 게시글 id", example = "1", required = true)
             @PathVariable Long id
     ) {
         postService.deletePost(id);

--- a/src/main/java/org/sopt/domain/BaseTimeEntity.java
+++ b/src/main/java/org/sopt/domain/BaseTimeEntity.java
@@ -1,0 +1,31 @@
+package org.sopt.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/org/sopt/domain/Like.java
+++ b/src/main/java/org/sopt/domain/Like.java
@@ -1,0 +1,48 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(
+        name = "likes", //like는 sql 검색 키워드라 테이블명을 like로 하면 위험하다고 함
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_like_user_post",
+                    columnNames = {"user_id", "post_id"} //한 유저가 같은 게시물에 좋아요 여러번 누르기 불가능하도록 db에서도 막아놓기
+            )
+        }
+)
+
+public class Like extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    protected Like() {}
+
+    public Like(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public Post getPost() {
+        return post;
+    }
+
+}

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -3,7 +3,7 @@ package org.sopt.domain;
 import jakarta.persistence.*;
 
 @Entity
-public class Post {
+public class Post extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;          // 게시글 상세 화면 — 특정 게시글 식별용
@@ -15,20 +15,16 @@ public class Post {
 
     protected Post() {}  // JPA 기본 생성자
 
-    private String createdAt; // 목록, 상세 화면 — 작성 시각
-
-    public Post(User user, String title, String content, String createdAt) {
+    public Post(User user, String title, String content) {
         this.user = user;
         this.title = title;
         this.content = content;
-        this.createdAt = createdAt;
     }
 
     public Long getId() { return id; }
     public String getTitle() { return title; }
     public String getContent() { return content; }
     public String getAuthor() { return user.getNickname();}
-    public String getCreatedAt() { return createdAt; }
 
     public void update(String title, String content) {
         this.title = title;
@@ -36,6 +32,6 @@ public class Post {
     }
 
     public String getInfo() {
-        return "[" + id + "] " + title + " - " + getAuthor() + " (" + createdAt + ")\n" + content;
+        return "[" + id + "] " + title + " - " + getAuthor() + " (" + getCreatedAt() + ")\n" + content;
     }
 }

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -2,8 +2,6 @@ package org.sopt.domain;
 
 import jakarta.persistence.*;
 
-import java.time.LocalDateTime;
-
 @Entity
 public class Post {
     @Id
@@ -12,7 +10,7 @@ public class Post {
     private String title;     // 목록, 상세, 글쓰기 화면 — 제목
     private String content;   // 목록(미리보기), 상세(전체) 화면 — 내용
     @ManyToOne(fetch = FetchType.LAZY)  // User : Post = 1 : N
-    @JoinColumn(name = "user_id")       // post 테이블에 user_id FK 컬럼이 생겨요
+    @JoinColumn(name = "user_id", nullable = false)       // post 테이블에 user_id FK 컬럼이 생겨요
     private User user;
 
     protected Post() {}  // JPA 기본 생성자

--- a/src/main/java/org/sopt/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/CreatePostRequest.java
@@ -1,6 +1,9 @@
 package org.sopt.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 // 게시글 작성 요청 (클라이언트 → 서버)
+@Schema(description = "게시글 작성 요청 DTO")
 public record CreatePostRequest(
         Long userId,
         String title,

--- a/src/main/java/org/sopt/dto/request/LikeRequest.java
+++ b/src/main/java/org/sopt/dto/request/LikeRequest.java
@@ -1,0 +1,10 @@
+package org.sopt.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "좋아요 요청 DTO")
+public record LikeRequest(
+        @Schema(description = "유저 id", example = "1")
+        Long userId
+        ) {
+}

--- a/src/main/java/org/sopt/dto/request/UpdatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/UpdatePostRequest.java
@@ -1,6 +1,9 @@
 package org.sopt.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 // 게시글 수정 요청
+@Schema(description = "게시글 수정 요청 DTO")
 public record UpdatePostRequest(
         String title,
         String content

--- a/src/main/java/org/sopt/dto/response/ApiResponse.java
+++ b/src/main/java/org/sopt/dto/response/ApiResponse.java
@@ -1,5 +1,8 @@
 package org.sopt.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "공통 API 응답 DTO")
 public record ApiResponse<T>(
         boolean success,
         String message,

--- a/src/main/java/org/sopt/dto/response/CreatePostResponse.java
+++ b/src/main/java/org/sopt/dto/response/CreatePostResponse.java
@@ -1,6 +1,9 @@
 package org.sopt.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 // 게시글 작성 응답
+@Schema(description = "게시글 작성 응답 DTO")
 public record CreatePostResponse(
         Long id
 ) {

--- a/src/main/java/org/sopt/dto/response/PostResponse.java
+++ b/src/main/java/org/sopt/dto/response/PostResponse.java
@@ -1,8 +1,10 @@
 package org.sopt.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.sopt.domain.Post;
 
 // 게시글 조회 응답
+@Schema(description = "게시글 조회 응답 DTO")
 public record PostResponse(
         Long id,
         String title,

--- a/src/main/java/org/sopt/dto/response/PostResponse.java
+++ b/src/main/java/org/sopt/dto/response/PostResponse.java
@@ -3,14 +3,25 @@ package org.sopt.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.sopt.domain.Post;
 
+import java.time.LocalDateTime;
+
 // 게시글 조회 응답
 @Schema(description = "게시글 조회 응답 DTO")
 public record PostResponse(
+        @Schema(description = "게시글 id", example = "1")
         Long id,
+
+        @Schema(description = "게시글 제목", example = "첫 번째 게시글")
         String title,
+
+        @Schema(description = "게시글 내용", example = "게시글 내용입니다.")
         String content,
+
+        @Schema(description = "작성자 닉네임", example = "가윤")
         String author,
-        String createdAt
+
+        @Schema(description = "작성 시각", example = "2026-05-01T12:00:00")
+        LocalDateTime createdAt
 ) {
     public static PostResponse from(Post post) {
         return new PostResponse(

--- a/src/main/java/org/sopt/exception/AlreadyLikedException.java
+++ b/src/main/java/org/sopt/exception/AlreadyLikedException.java
@@ -1,0 +1,8 @@
+package org.sopt.exception;
+
+public class AlreadyLikedException extends RuntimeException {
+
+    public AlreadyLikedException() {
+        super("이미 좋아요를 눌렀습니다.");
+    }
+}

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -5,12 +5,28 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.sopt.exception.AlreadyLikedException;
+import org.sopt.exception.LikeNotFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(PostNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handlePostNotFound(PostNotFoundException e) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error(e.getMessage()));
+    }
+
+    @ExceptionHandler(AlreadyLikedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAlreadyLiked(AlreadyLikedException e) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(e.getMessage()));
+    }
+
+    @ExceptionHandler(LikeNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleLikeNotFound(LikeNotFoundException e) {
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
                 .body(ApiResponse.error(e.getMessage()));

--- a/src/main/java/org/sopt/exception/LikeNotFoundException.java
+++ b/src/main/java/org/sopt/exception/LikeNotFoundException.java
@@ -1,0 +1,8 @@
+package org.sopt.exception;
+
+public class LikeNotFoundException extends RuntimeException {
+
+    public LikeNotFoundException() {
+        super("존재하지 않는 좋아요 입니다.");
+    }
+}

--- a/src/main/java/org/sopt/repository/LikeRepository.java
+++ b/src/main/java/org/sopt/repository/LikeRepository.java
@@ -1,0 +1,17 @@
+package org.sopt.repository;
+
+import org.sopt.domain.Like;
+import org.sopt.domain.Post;
+import org.sopt.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long>{
+
+    boolean existsByUserAndPost(User user, Post post);
+    Optional<Like> findByUserAndPost(User user, Post post);
+
+}

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -4,8 +4,6 @@ import org.sopt.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 }

--- a/src/main/java/org/sopt/service/LikeService.java
+++ b/src/main/java/org/sopt/service/LikeService.java
@@ -1,0 +1,80 @@
+package org.sopt.service;
+
+import org.springframework.transaction.annotation.Transactional;
+import org.sopt.domain.Like;
+import org.sopt.domain.Post;
+import org.sopt.domain.User;
+import org.sopt.dto.request.LikeRequest;
+import org.sopt.exception.AlreadyLikedException;
+import org.sopt.exception.ErrorCode;
+import org.sopt.exception.LikeNotFoundException;
+import org.sopt.exception.NotFoundException;
+import org.sopt.repository.LikeRepository;
+import org.sopt.repository.PostRepository;
+import org.sopt.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+
+    public LikeService(
+            LikeRepository likeRepository,
+            UserRepository userRepository,
+            PostRepository postRepository
+    ) {
+        this.likeRepository = likeRepository;
+        this.userRepository = userRepository;
+        this.postRepository = postRepository;
+    }
+
+    @Transactional
+    public void addLike(Long postId, LikeRequest request){
+        validateLikeRequest(postId, request);
+
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.POST_NOT_FOUND));
+
+        boolean alreadyLiked = likeRepository.existsByUserAndPost(user, post);
+
+        if (alreadyLiked) {
+            throw new AlreadyLikedException();
+        }
+
+        Like like = new Like(user, post);
+        likeRepository.save(like);
+    }
+
+    @Transactional
+    public void cancelLike(Long postId, LikeRequest request){
+        validateLikeRequest(postId, request);
+
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.POST_NOT_FOUND));
+
+        Like like = likeRepository.findByUserAndPost(user, post)
+                .orElseThrow(LikeNotFoundException::new);
+
+        likeRepository.delete(like);
+    }
+
+    private void validateLikeRequest(Long postId, LikeRequest request) {
+        if (postId == null) {
+            throw new IllegalArgumentException("게시글 id는 필수입니다.");
+        }
+
+        if (request == null || request.userId() == null) {
+            throw new IllegalArgumentException("사용자 id는 필수입니다.");
+        }
+    }
+
+}

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -13,7 +13,6 @@ import org.sopt.repository.PostRepository;
 import org.sopt.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -37,13 +36,11 @@ public class PostService {
 
         User user = userRepository.findById(request.userId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
-        String createdAt = LocalDateTime.now().toString();
 
         Post post = new Post(
                 user,
                 request.title(),
-                request.content(),
-                createdAt
+                request.content()
         );
 
         postRepository.save(post);


### PR DESCRIPTION
# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제
- [x] User 엔티티를 만들고, Post에 작성자 연관관계를 추가해주세요. 게시글 작성 시 userId를 받아서 연결해주세요
- [x] 전체 API에 Swagger 어노테이션을 적용하고, Swagger UI에서 API를 직접 테스트해보세요. 테스트 화면을 PR에 첨부해주세요

<img width="1079" height="1501" alt="image" src="https://github.com/user-attachments/assets/e1ad55ed-b365-475a-8307-2390f950304a" />
<img width="1075" height="1249" alt="image" src="https://github.com/user-attachments/assets/4a4d7375-9786-48ad-983e-66b01c5be8b1" />
<img width="1074" height="1141" alt="image" src="https://github.com/user-attachments/assets/691e24f5-2df4-4c51-a116-1917a8225f5c" />
<img width="1073" height="1554" alt="image" src="https://github.com/user-attachments/assets/a3e8e87a-2046-4922-9cbb-344b94d1db42" />
<img width="1076" height="1181" alt="image" src="https://github.com/user-attachments/assets/3e38cb76-da2c-49ca-add0-1acb20b25022" />


- [x] BaseTimeEntity를 게시글에 적용해주세요

<br>

### 선택과제
- [x] Like 엔티티를 만들고, 좋아요 추가/취소 API를 구현해주세요.
같은 유저가 같은 게시글에 중복 좋아요를 누를 수 없게 예외처리해주세요
- [ ] 게시글 목록 조회 시 좋아요 수도 함께 반환해주세요. N+1 문제가 발생하지 않도록 fetch join을 적용하고, 적용 전후 실행되는 쿼리를 show-sql: true로 확인해서 PR에 비교해서 첨부해주세요
- [ ] 좋아요 동시성 문제를 @Version으로 해결하고, 낙관적 락 충돌 시 재시도 로직을 구현해주세요
- [ ] 게시글을 제목으로 검색하는 API를 JPQL @Query를 사용해서 구현해주세요. 검색 결과에 작성자 닉네임도 함께 반환하고, fetch join으로 N+1이 발생하지 않도록 해주세요
- [ ] PostRepositoryCustom 인터페이스와 PostRepositoryCustomImpl 구현체를 만들고, 위의 검색 기능을 QueryDSL로 재구현해주세요. 제목 키워드와 작성자 닉네임을 동시에 받아 동적으로 조건을 조합해주세요. 
- [ ] PostRepository가 JpaRepository와 PostRepositoryCustom을 함께 상속하도록 구성해주세요

<br>

### **구현한 내용에 대해서 설명해주세요**
`BaseTimeEntity`를 생성하고 `Post`가 이를 상속하도록 수정하여 `createdAt`, `updatedAt`을 자동으로 관리하도록 변경했습니다.
Swagger 설정 클래스와 Swagger 어노테이션을 추가하여 API 문서를 확인하고 테스트할 수 있도록 했습니다.
`PostResponse`의 `createdAt` 타입을 `String`에서 `LocalDateTime`으로 변경했습니다.
<br>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**
게시글에 꼭 작성자가 존재해야 하니까 `post.user_id`에 `nullable = false`를 설정했습니다. 
Swagger 적용 중 Spring Boot 버전과 호환되는 springdoc-openapi 버전을 사용해야 해서 `2.5.0` 버전으로 설정했습니다.

AlreadyLikedException을 enum으로 만들면 안 되는 이유가 무엇인지 궁금했는데, `enum`은 여러 개의 고정된 상수 값을 관리할 때 사용하는 타입이라고 합니다.  예를 들어 `USER_NOT_FOUND`, `POST_NOT_FOUND`처럼 에러의 종류를 모아두는 `ErrorCode`에는 `enum`이 적합합니다. 반면 여기 `AlreadyLikedException`은 단순한 에러 종류가 아니라, 실제 서비스 로직에서 `throw`를 통해 발생시켜야 하는 예외입니다. 예외로 던지기 위해서는 RuntimeException을 상속한 클래스여야 하는데 enum은 이미 자바 내부적으로 Enum을 상속하고 있기 때문에 RuntimeException을 함께 상속할 수 없습니다. 따라서 AlreadyLikedException은 enum이 아니라 RuntimeException을 상속하는 클래스로 구현해야 한다고 합니다!

<br>

---
### **키워드 과제 정리내용**
**ERD 란 무엇인가요?**
: 데이터베이스 구조를 그림으로 표현한 문서이다. db에 어떤 테이블이 있고, 테이블이 어떤 컬럼을 가지고, 서로 어떤 관계인지를 보여준다. 

**구현한 내용에 대해 ERD 구조도를 ERD Cloud에 그려서 올려주세요.**
<img width="673" height="588" alt="image" src="https://github.com/user-attachments/assets/224eb7d4-df7d-4a08-a229-08589b38dee6" />

**QueryDSL이란 무엇이고, JPQL과 어떤 차이가 있나요?**
JPQL은 JPA에서 엔티티 객체를 대상으로 문자열로 작성하는 쿼리 언어이다. QueryDSL은 JPQL을 더 안전하고 편하게 작성할 수 있도록 도와주는 Java 기반 쿼리 작성 도구이다. 
| 구분 | JPQL | QueryDSL |
| --- | --- | --- |
| 작성 방식 | 문자열 기반으로 쿼리 작성 | Java 코드 기반으로 쿼리 작성 |
| 오타 확인 | 실행 시점에 오류 발견 | 컴파일 시점에 오류 발견 가능 |
| 동적 쿼리 | 조건이 많아질수록 복잡해질 수 있음 | 조건 조합이 비교적 깔끔함 |
| 가독성 | 쿼리가 길어지면 가독성이 떨어질 수 있음 | 메서드 체이닝 방식으로 가독성이 좋음 |
| 사용 난이도 | 비교적 간단함 | 초기 설정이 조금 필요함 |
| 주요 장점 | SQL과 비슷해 이해하기 쉬움 | 타입 안전성과 동적 쿼리 작성에 유리함 |
| 주요 단점 | 문자열 오타를 컴파일 단계에서 잡기 어려움 | Q클래스 생성 등 추가 설정이 필요함 |
<br>

---

## 🚨 참고 사항
